### PR TITLE
Bug fix start time not editable in sources

### DIFF
--- a/src/components/Sources/EditSourceForm.tsx
+++ b/src/components/Sources/EditSourceForm.tsx
@@ -10,6 +10,7 @@ import { SourceConfigInput } from './SourceConfigInput';
 import Input from '../UI/Input/Input';
 
 interface EditSourceFormProps {
+  mutate: (...args: any) => any;
   showForm: boolean;
   setShowForm: (...args: any) => any;
   sourceId: string;
@@ -43,6 +44,7 @@ type AutoCompleteOption = {
 };
 
 const EditSourceForm = ({
+  mutate,
   showForm,
   setShowForm,
   sourceId,
@@ -185,6 +187,7 @@ const EditSourceForm = ({
       });
       handleClose();
       successToast('Source update', [], globalContext);
+      mutate();
     } catch (err: any) {
       console.error(err);
       errorToast(err.message, [], globalContext);

--- a/src/components/Sources/SourceConfigInput.tsx
+++ b/src/components/Sources/SourceConfigInput.tsx
@@ -55,7 +55,7 @@ export const SourceConfigInput = ({
                   variant="outlined"
                   type={showPasswords[`${spec.field}`] ? 'text' : 'password'}
                   required={spec.required}
-                  value={spec?.default}
+                  defaultValue={spec?.default}
                   InputProps={{
                     endAdornment: (
                       <InputAdornment position="end">
@@ -88,8 +88,9 @@ export const SourceConfigInput = ({
                   register={registerFormFieldValue}
                   name={`config.${spec.field}`}
                   required={spec.required}
-                  value={spec?.default}
+                  defaultValue={spec?.default}
                   disabled={source ? true : false}
+                  inputProps={{ pattern: spec?.pattern }}
                 ></Input>
                 <Box sx={{ m: 2 }} />
               </React.Fragment>
@@ -122,7 +123,7 @@ export const SourceConfigInput = ({
                 register={registerFormFieldValue}
                 name={`config.${spec.field}`}
                 required={spec.required}
-                value={spec?.default}
+                defaultValue={spec?.default}
                 type="number"
               ></Input>
               <Box sx={{ m: 2 }} />

--- a/src/components/Sources/Sources.tsx
+++ b/src/components/Sources/Sources.tsx
@@ -142,6 +142,7 @@ export const Sources = () => {
         setShowForm={setShowCreateSourceDialog}
       />
       <EditSourceForm
+        mutate={mutate}
         showForm={showEditSourceDialog}
         setShowForm={setShowEditSourceDialog}
         sourceId={sourceIdToEdit}


### PR DESCRIPTION
Start time was not editable since we have `value={spec?.default}` whereas it should be `defaultValue={spec?.default}`. Also added parttern matchin for the format of start date