### PR TITLE
name <= 25 characters

### DIFF
--- a/src/components/Destinations/DestinationForm.tsx
+++ b/src/components/Destinations/DestinationForm.tsx
@@ -256,7 +256,13 @@ const DestinationForm = ({ showForm, setShowForm, warehouse, mutate }: Destinati
       <Controller
         name="name"
         control={control}
-        rules={{ required: 'Destination type is required' }}
+        rules={{
+          required: 'Destination type is required',
+          maxLength: {
+            value: 25,
+            message: 'Warehouse name cannot exceed 25 characters',
+          },
+        }}
         render={({ field: { ref, ...rest }, fieldState }) => (
           <Input
             {...rest}
@@ -266,6 +272,7 @@ const DestinationForm = ({ showForm, setShowForm, warehouse, mutate }: Destinati
             label="Name*"
             variant="outlined"
             data-testid="dest-name"
+            inputProps={{ maxLength: 25 }}
           ></Input>
         )}
       />


### PR DESCRIPTION
Restrict the name of the warehouse to 25 characters

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a 25-character maximum length restriction for the "name" field in the Destination form.

* **Bug Fixes**
  * Improved validation to prevent entering names longer than 25 characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->