### PR TITLE
crashed is also a failure state

### DIFF
--- a/src/components/Flows/FlowLogs.tsx
+++ b/src/components/Flows/FlowLogs.tsx
@@ -294,12 +294,11 @@ const Row = ({ logDetail }: { logDetail: DeploymentObject }) => {
         sx={{
           position: 'relative',
           p: 2,
-          background:
-            logDetail.status === 'FAILED'
-              ? 'rgba(211, 47, 47, 0.2)'
-              : logDetail.state_name === 'DBT_TEST_FAILED'
-                ? 'rgba(218, 134, 45, 0.2)'
-                : 'unset',
+          background: ['FAILED', 'CRASHED'].includes(logDetail.status)
+            ? 'rgba(211, 47, 47, 0.2)'
+            : logDetail.state_name === 'DBT_TEST_FAILED'
+              ? 'rgba(218, 134, 45, 0.2)'
+              : 'unset',
         }}
       >
         <TableCell


### PR DESCRIPTION
Currently this confusing. In dhwani's case, some of the failure are due to CRASHED but they show completed or white in color under the `View history` which is misleading. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved log highlighting: rows now display a red background for both failed and crashed statuses, ensuring critical errors are clearly visible.
  * Preserved existing behavior for specific test failures, which continue to show an orange background.
  * Enhances readability and consistency in the logs view without altering functionality or performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->