### PR TITLE
confusing label for the generic sql operation

### DIFF
--- a/src/components/TransformWorkflow/FlowEditor/Components/OperationPanel/Forms/GenericSqlOpForm.tsx
+++ b/src/components/TransformWorkflow/FlowEditor/Components/OperationPanel/Forms/GenericSqlOpForm.tsx
@@ -131,7 +131,7 @@ const GenericSqlOpForm = ({
       <form onSubmit={handleSubmit(handleSave)}>
         <Box sx={{ padding: '32px 16px 0px 16px' }}>
           <Box sx={{ display: 'flex', alignItems: 'center' }}>
-            <FormLabel sx={{ mr: 1, color: 'black' }}>SELECT*</FormLabel>
+            <FormLabel sx={{ mr: 1, color: 'black' }}>SELECT</FormLabel>
             <Box sx={{ display: 'inline-block' }}>
               <InfoTooltip title={'Output if all values in a row are null'} />
             </Box>

--- a/src/components/TransformWorkflow/FlowEditor/Components/OperationPanel/Forms/__tests__/GenericSqlOpForm.test.tsx
+++ b/src/components/TransformWorkflow/FlowEditor/Components/OperationPanel/Forms/__tests__/GenericSqlOpForm.test.tsx
@@ -55,7 +55,7 @@ describe('GenericSqlOpForm', () => {
 
   it('renders the form', () => {
     render(<GenericSqlOpForm {...defaultProps} />);
-    expect(screen.getByText('SELECT*')).toBeInTheDocument();
+    expect(screen.getByText('SELECT')).toBeInTheDocument();
     expect(screen.getByText('FROM Test Input Model')).toBeInTheDocument();
   });
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated SQL operation form label to display “SELECT” instead of “SELECT*,” removing the asterisk indicator for a cleaner, less confusing UI. Field remains required; validation behavior is unchanged.

* **Tests**
  * Adjusted form rendering test expectations to reflect the updated label text (“SELECT” without asterisk).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->