### PR TITLE
ability to have null and not null operators in filter & case when op

### DIFF
--- a/src/components/TransformWorkflow/FlowEditor/Components/OperationPanel/Forms/CaseWhenOpForm.tsx
+++ b/src/components/TransformWorkflow/FlowEditor/Components/OperationPanel/Forms/CaseWhenOpForm.tsx
@@ -63,6 +63,14 @@ export const LogicalOperators = [
     label: 'Greater Than >',
   },
   {
+    id: 'IS NOT NULL',
+    label: 'Is Not Null',
+  },
+  {
+    id: 'IS NULL',
+    label: 'Is Null',
+  },
+  {
     id: '<',
     label: 'Less Than <',
   },
@@ -104,7 +112,14 @@ const ClauseOperands = ({
   return (
     <>
       {operandFields
-        .slice(0, data.logicalOp?.id === 'between' ? 2 : 1)
+        .slice(
+          0,
+          ['IS NULL', 'IS NOT NULL'].includes(data.logicalOp?.id)
+            ? 0
+            : data.logicalOp?.id === 'between'
+              ? 2
+              : 1
+        )
         .map((operandField, operandIndex) => {
           const operandRadioValue = watch(`clauses.${clauseIndex}.operands.${operandIndex}.type`);
 
@@ -282,12 +297,14 @@ const CaseWhenOpForm = ({
         when_clauses: data.clauses.map((clause: clauseType) => {
           return {
             column: clause.filterCol,
-            operands: clause.operands
-              .map((op: { type: string; col_val: string; const_val: string }) => ({
-                value: op.type === 'col' ? op.col_val : parseStringForNull(op.const_val),
-                is_col: op.type === 'col',
-              }))
-              .slice(0, clause.logicalOp?.id === 'between' ? 2 : 1),
+            operands: ['IS NULL', 'IS NOT NULL'].includes(clause.logicalOp?.id)
+              ? [] // No operands for null checks
+              : clause.operands
+                  .map((op: { type: string; col_val: string; const_val: string }) => ({
+                    value: op.type === 'col' ? op.col_val : parseStringForNull(op.const_val),
+                    is_col: op.type === 'col',
+                  }))
+                  .slice(0, clause.logicalOp?.id === 'between' ? 2 : 1),
             then: {
               value:
                 clause.then.type === 'col'
@@ -373,11 +390,13 @@ const CaseWhenOpForm = ({
           id: '',
           label: '',
         },
-        operands: clause.operands.map((op: GenericOperand) => ({
-          type: op.is_col ? 'col' : 'val',
-          col_val: op.is_col ? op.value : '',
-          const_val: !op.is_col ? op.value : '',
-        })),
+        operands: ['IS NULL', 'IS NOT NULL'].includes(clause.operator)
+          ? [] // Empty operands for null operators
+          : clause.operands.map((op: GenericOperand) => ({
+              type: op.is_col ? 'col' : 'val',
+              col_val: op.is_col ? op.value : '',
+              const_val: !op.is_col ? op.value : '',
+            })),
         then: {
           type: clause.then.is_col ? 'col' : 'val',
           col_val: clause.then.is_col ? clause.then.value : '',

--- a/src/components/TransformWorkflow/FlowEditor/Components/OperationPanel/Forms/CaseWhenOpForm.tsx
+++ b/src/components/TransformWorkflow/FlowEditor/Components/OperationPanel/Forms/CaseWhenOpForm.tsx
@@ -114,9 +114,9 @@ const ClauseOperands = ({
       {operandFields
         .slice(
           0,
-          ['IS NULL', 'IS NOT NULL'].includes(data.logicalOp?.id)
+          ['IS NULL', 'IS NOT NULL'].includes(data.logicalOp?.id || '')
             ? 0
-            : data.logicalOp?.id === 'between'
+            : (data.logicalOp?.id || '') === 'between'
               ? 2
               : 1
         )
@@ -297,14 +297,14 @@ const CaseWhenOpForm = ({
         when_clauses: data.clauses.map((clause: clauseType) => {
           return {
             column: clause.filterCol,
-            operands: ['IS NULL', 'IS NOT NULL'].includes(clause.logicalOp?.id)
+            operands: ['IS NULL', 'IS NOT NULL'].includes(clause.logicalOp?.id || '')
               ? [] // No operands for null checks
               : clause.operands
                   .map((op: { type: string; col_val: string; const_val: string }) => ({
                     value: op.type === 'col' ? op.col_val : parseStringForNull(op.const_val),
                     is_col: op.type === 'col',
                   }))
-                  .slice(0, clause.logicalOp?.id === 'between' ? 2 : 1),
+                  .slice(0, (clause.logicalOp?.id || '') === 'between' ? 2 : 1),
             then: {
               value:
                 clause.then.type === 'col'
@@ -312,7 +312,7 @@ const CaseWhenOpForm = ({
                   : parseStringForNull(clause.then.const_val),
               is_col: clause.then.type === 'col',
             },
-            operator: clause.logicalOp?.id,
+            operator: clause.logicalOp?.id || '',
           };
         }),
         else_clause: {

--- a/src/components/TransformWorkflow/FlowEditor/Components/OperationPanel/Forms/WhereFilterOpForm.tsx
+++ b/src/components/TransformWorkflow/FlowEditor/Components/OperationPanel/Forms/WhereFilterOpForm.tsx
@@ -78,6 +78,8 @@ const WhereFilterOpForm = ({
 
   const radioValue = watch('operand.type');
   const advanceFilter = watch('advanceFilter');
+  const logicalOp = watch('logicalOp');
+  const isNullOperator = ['IS NULL', 'IS NOT NULL'].includes(logicalOp?.id);
 
   const fetchAndSetSourceColumns = async () => {
     if (node) {
@@ -95,13 +97,15 @@ const WhereFilterOpForm = ({
           {
             column: data.filterCol,
             operator: data.logicalOp.id,
-            operand: {
-              value:
-                data.operand.type === 'col'
-                  ? data.operand.col_val
-                  : parseStringForNull(data.operand.const_val),
-              is_col: data.operand.type === 'col',
-            },
+            operand: ['IS NULL', 'IS NOT NULL'].includes(data.logicalOp.id)
+              ? null // No operand for null checks
+              : {
+                  value:
+                    data.operand.type === 'col'
+                      ? data.operand.col_val
+                      : parseStringForNull(data.operand.const_val),
+                  is_col: data.operand.type === 'col',
+                },
           },
         ],
         sql_snippet: data.sql_snippet,
@@ -167,13 +171,15 @@ const WhereFilterOpForm = ({
         clauseFields = {
           filterCol: column,
           logicalOp: LogicalOperators.find((op) => op.id === operator),
-          operand: operand
-            ? {
-                type: operand.is_col ? 'col' : 'val',
-                col_val: operand.is_col ? operand.value : '',
-                const_val: !operand.is_col ? operand.value : '',
-              }
-            : { type: 'col', col_val: '', const_val: '' },
+          operand: ['IS NULL', 'IS NOT NULL'].includes(operator)
+            ? { type: 'val', col_val: '', const_val: '' } // Default structure for null operators
+            : operand
+              ? {
+                  type: operand.is_col ? 'col' : 'val',
+                  col_val: operand.is_col ? operand.value : '',
+                  const_val: !operand.is_col ? operand.value : '',
+                }
+              : { type: 'col', col_val: '', const_val: '' },
         };
       }
 
@@ -251,75 +257,79 @@ const WhereFilterOpForm = ({
               )}
             />
             <Box sx={{ m: 2 }} />
-            <Controller
-              name={`operand.type`}
-              control={control}
-              render={({ field }) => {
-                return (
-                  <RadioGroup
-                    {...field}
-                    defaultValue="col"
-                    sx={{
-                      display: 'flex',
-                      flexDirection: 'row',
-                      gap: '20px',
+            {!isNullOperator && (
+              <>
+                <Controller
+                  name={`operand.type`}
+                  control={control}
+                  render={({ field }) => {
+                    return (
+                      <RadioGroup
+                        {...field}
+                        defaultValue="col"
+                        sx={{
+                          display: 'flex',
+                          flexDirection: 'row',
+                          gap: '20px',
+                        }}
+                      >
+                        <FormControlLabel
+                          value="col"
+                          control={<Radio />}
+                          label="Column"
+                          disabled={isNonAdancedFieldsDisabled}
+                        />
+                        <FormControlLabel
+                          value="val"
+                          control={<Radio />}
+                          label="Value"
+                          disabled={isNonAdancedFieldsDisabled}
+                        />
+                      </RadioGroup>
+                    );
+                  }}
+                />
+                {radioValue === 'col' ? (
+                  <Controller
+                    control={control}
+                    rules={{
+                      required: advanceFilter === 'no' && 'Column is required',
                     }}
-                  >
-                    <FormControlLabel
-                      value="col"
-                      control={<Radio />}
-                      label="Column"
-                      disabled={isNonAdancedFieldsDisabled}
-                    />
-                    <FormControlLabel
-                      value="val"
-                      control={<Radio />}
-                      label="Value"
-                      disabled={isNonAdancedFieldsDisabled}
-                    />
-                  </RadioGroup>
-                );
-              }}
-            />
-            {radioValue === 'col' ? (
-              <Controller
-                control={control}
-                rules={{
-                  required: advanceFilter === 'no' && 'Column is required',
-                }}
-                key="operand.col_val"
-                name="operand.col_val"
-                render={({ field, fieldState }) => (
-                  <Autocomplete
-                    {...field}
-                    data-testid="checkAgainstColumn"
-                    error={!!fieldState.error}
-                    helperText={fieldState.error?.message}
-                    fieldStyle="transformation"
-                    options={srcColumns}
-                    disabled={isNonAdancedFieldsDisabled}
-                    placeholder="Select column*"
+                    key="operand.col_val"
+                    name="operand.col_val"
+                    render={({ field, fieldState }) => (
+                      <Autocomplete
+                        {...field}
+                        data-testid="checkAgainstColumn"
+                        error={!!fieldState.error}
+                        helperText={fieldState.error?.message}
+                        fieldStyle="transformation"
+                        options={srcColumns}
+                        disabled={isNonAdancedFieldsDisabled}
+                        placeholder="Select column*"
+                      />
+                    )}
+                  />
+                ) : (
+                  <Controller
+                    control={control}
+                    key="operand.const_val"
+                    name="operand.const_val"
+                    render={({ field, fieldState }) => (
+                      <Input
+                        {...field}
+                        error={!!fieldState.error}
+                        helperText={fieldState.error?.message}
+                        fieldStyle="transformation"
+                        label=""
+                        sx={{ padding: '0' }}
+                        placeholder="Enter the value"
+                        disabled={isNonAdancedFieldsDisabled}
+                      />
+                    )}
                   />
                 )}
-              />
-            ) : (
-              <Controller
-                control={control}
-                key="operand.const_val"
-                name="operand.const_val"
-                render={({ field, fieldState }) => (
-                  <Input
-                    {...field}
-                    error={!!fieldState.error}
-                    helperText={fieldState.error?.message}
-                    fieldStyle="transformation"
-                    label=""
-                    sx={{ padding: '0' }}
-                    placeholder="Enter the value"
-                    disabled={isNonAdancedFieldsDisabled}
-                  />
-                )}
-              />
+              </>
             )}
             <Box sx={{ m: 2 }} />
             <Box


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added IS NULL and IS NOT NULL logical operators for workflow filtering and case-when clauses.
  * UI now hides operand selection when a null-check operator is chosen, simplifying input.
  * Save/edit and prefill behavior updated so clauses using null-check operators emit empty/no operands, preserving previous behavior for other operators.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->